### PR TITLE
logging: Standardise log output

### DIFF
--- a/etc/kayobe/kolla/config/fluentd/filter/02-standardise-log-messages.conf
+++ b/etc/kayobe/kolla/config/fluentd/filter/02-standardise-log-messages.conf
@@ -1,0 +1,27 @@
+# Each log source should provide the log message, under the 'message' field
+# and at a minimum the dimensions: 'log_level', 'programname', 'timestamp'
+# and 'Hostname'.
+
+# Add a timestamp dimension to all logs to record the event time. The
+# event time is the time extracted from the log message in all cases
+# where the time_key is set, and the time the record entered fluentd
+# if no time_key is set. Kolla sets a time_key for OpenStack service
+# logs.
+<filter *.**>
+  @type record_transformer
+  <record>
+    timestamp ${time}
+  </record>
+</filter>
+
+# Kolla saves all logs under the 'Payload' field. The fluentd-monasca
+# plugin assumes that they are saved under the 'message' field. Here
+# we map the 'Payload' field to the 'message' field for all logs.
+<filter *.**>
+  @type record_transformer
+  enable_ruby true
+  <record>
+    message ${record["Payload"]}
+  </record>
+  remove_keys Payload
+</filter>

--- a/etc/kayobe/kolla/config/fluentd/output/00-local.conf
+++ b/etc/kayobe/kolla/config/fluentd/output/00-local.conf
@@ -1,0 +1,45 @@
+<match syslog.local0.**>
+  @type copy
+  <store>
+    @type monasca
+    keystone_url {% raw %}{{ admin_protocol }}://{{ kolla_internal_fqdn }}:{{ keystone_admin_port }}
+{% endraw %}
+    monasca_log_api http://{{ 'alaska_prv' | net_ip(groups['monitoring'][0]) }}:5607
+    monasca_log_api_version v3.0
+    username monasca-agent
+    password {{ secrets_monasca_agent_password }}
+    domain_id default
+    project_name monasca
+  </store>
+  <store>
+    @type file
+    path /var/log/kolla/swift/swift_latest.*.log
+    utc
+    append true
+    compress gzip
+  </store>
+</match>
+
+<match syslog.local1.**>
+  @type copy
+  <store>
+    @type monasca
+    keystone_url {% raw %}{{ admin_protocol }}://{{ kolla_internal_fqdn }}:{{ keystone_admin_port }}
+{% endraw %}
+    monasca_log_api http://{{ 'alaska_prv' | net_ip(groups['monitoring'][0]) }}:5607
+    monasca_log_api_version v3.0
+    username monasca-agent
+    password {{ secrets_monasca_agent_password }}
+    domain_id default
+    project_name monasca
+  </store>
+  <store>
+    @type file
+    path /var/log/kolla/haproxy/haproxy_latest.*.log
+    output_tag false
+    output_time false
+    utc
+    append true
+    compress gzip
+  </store>
+</match>

--- a/etc/kayobe/kolla/config/fluentd/output/00-local.conf
+++ b/etc/kayobe/kolla/config/fluentd/output/00-local.conf
@@ -2,7 +2,7 @@
   @type copy
   <store>
     @type monasca
-    keystone_url {% raw %}{{ admin_protocol }}://{{ kolla_internal_fqdn }}:{{ keystone_admin_port }}
+    keystone_url {% raw %}{{ keystone_internal_url }}
 {% endraw %}
     monasca_log_api http://{{ 'alaska_prv' | net_ip(groups['monitoring'][0]) }}:5607
     monasca_log_api_version v3.0
@@ -24,7 +24,7 @@
   @type copy
   <store>
     @type monasca
-    keystone_url {% raw %}{{ admin_protocol }}://{{ kolla_internal_fqdn }}:{{ keystone_admin_port }}
+    keystone_url {% raw %}{{ keystone_internal_url }}
 {% endraw %}
     monasca_log_api http://{{ 'alaska_prv' | net_ip(groups['monitoring'][0]) }}:5607
     monasca_log_api_version v3.0

--- a/etc/kayobe/kolla/config/fluentd/output/01-es.conf
+++ b/etc/kayobe/kolla/config/fluentd/output/01-es.conf
@@ -1,0 +1,2 @@
+# Override Kolla configuration for logging directly to
+# Elasticsearch.

--- a/etc/kayobe/kolla/config/fluentd/output/02-monasca.conf
+++ b/etc/kayobe/kolla/config/fluentd/output/02-monasca.conf
@@ -2,7 +2,7 @@
     type copy
     <store>
        @type monasca
-       keystone_url {% raw %}{{ admin_protocol }}://{{ kolla_internal_fqdn }}:{{ keystone_admin_port }}
+       keystone_url {% raw %}{{ keystone_internal_url }}
 {% endraw %}
        monasca_log_api http://{{ 'alaska_prv' | net_ip(groups['monitoring'][0]) }}:5607
        monasca_log_api_version v3.0


### PR DESCRIPTION
- Some filters have been added to standardise log output
  from fluentd.

- Works around the configuration of Elasticsearch as a
  fluentd output by writing over Kolla's config
  (bug #1725266).