### PR TITLE
Set neutron ML2 mechanism drivers explicitly

### DIFF
--- a/etc/kayobe/neutron.yml
+++ b/etc/kayobe/neutron.yml
@@ -4,6 +4,9 @@
 
 # List of Neutron ML2 mechanism drivers to use.
 #kolla_neutron_ml2_mechanism_drivers:
+kolla_neutron_ml2_mechanism_drivers:
+  - openvswitch
+  - genericswitch
 
 # List of Neutron ML2 type drivers to use.
 #kolla_neutron_ml2_type_drivers:


### PR DESCRIPTION
Kayobe no longer provides a default, instead using kolla-ansible's default.