### PR TITLE
TSK-1986: Enable automated cleaning of disks

### DIFF
--- a/etc/kayobe/kolla/config/ironic/ironic-conductor.conf
+++ b/etc/kayobe/kolla/config/ironic/ironic-conductor.conf
@@ -1,0 +1,4 @@
+[conductor]
+# Enable automated cleaning. To save time this uses ATA secure erase when
+# supported.
+automated_clean=true


### PR DESCRIPTION
Each time an Ironic node is returned to the 'available' state
all disks will be erased, using ATA secure erase where
available. No changes to the Ironic Python Agent ramdisk are
required for this to work. The cleaning steps are listed on
the nodes driver_info.