### PR TITLE
Build IPA image with StackHPC hardware managers

### DIFF
--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -5,10 +5,10 @@
 # Ironic Python Agent (IPA) image build configuration.
 
 # Whether to build IPA images from source.
-#ipa_build_images:
+ipa_build_images: True
 
 # URL of IPA source repository.
-#ipa_build_source_url:
+ipa_build_source_url: "https://github.com/stackhpc/ironic-python-agent"
 
 # Version of IPA source repository.
 #ipa_build_source_version:
@@ -27,6 +27,8 @@
 # List of additional Diskimage Builder (DIB) elements to use when building IPA
 # images.
 #ipa_build_dib_elements_extra:
+ipa_build_dib_elements_extra:
+  - "stackhpc-ipa-hardware-managers"
 
 # List of Diskimage Builder (DIB) elements to use when building IPA images.
 #ipa_build_dib_elements:
@@ -46,6 +48,11 @@
 # List of git repositories containing Diskimage Builder (DIB) elements. See
 # stackhpc.os-images role for usage.
 #ipa_build_dib_git_elements:
+ipa_build_dib_git_elements:
+  - repo: "https://github.com/stackhpc/stackhpc-image-elements"
+    local: "{{ source_checkout_path }}/stackhpc-image-elements"
+    version: "master"
+    elements_path: "elements"
 
 ###############################################################################
 # Ironic Python Agent (IPA) images configuration.


### PR DESCRIPTION
This builds the IPA ramdisk so that it includes stackhpc-ipa-hardware-managers for checking the BIOS version.

Do we want to include any extra DIB elements? ipa_extra_hardware for inspection?