### PR TITLE
Create an inspector rule to set the expected BIOS version

### DIFF
--- a/etc/kayobe/inspector.yml
+++ b/etc/kayobe/inspector.yml
@@ -100,6 +100,16 @@ inspector_lldp_switch_port_interface_map:
 
 # List of additional ironic inspector rules.
 #inspector_rules_extra:
+inspector_rules_extra:
+  - description: "Set the expected BIOS version."
+    conditions:
+    - field: "data://inventory.system_vendor.product_name"
+      op: "matches"
+      value: "^PowerEdge R630$"
+    actions:
+    - action: "set-attribute"
+      path: "extra/system_vendor/bios_version"
+      value: "2.6.0"
 
 # List of all ironic inspector rules.
 #inspector_rules:

--- a/etc/kayobe/inspector.yml
+++ b/etc/kayobe/inspector.yml
@@ -101,11 +101,20 @@ inspector_lldp_switch_port_interface_map:
 # List of additional ironic inspector rules.
 #inspector_rules_extra:
 inspector_rules_extra:
-  - description: "Set the expected BIOS version."
+  - description: "Set the expected BIOS version for PowerEdge R630/R730/R730XD nodes."
     conditions:
     - field: "data://inventory.system_vendor.product_name"
       op: "matches"
-      value: "^PowerEdge R630$"
+      value: "^(PowerEdge R630|PowerEdge R730|PowerEdge R730xd)$"
+    actions:
+    - action: "set-attribute"
+      path: "extra/system_vendor/bios_version"
+      value: "2.6.0"
+  - description: "Set the expected BIOS version for PowerEdge C1430."
+    conditions:
+    - field: "data://inventory.system_vendor.product_name"
+      op: "matches"
+      value: "^(PowerEdge C4130)$"
     actions:
     - action: "set-attribute"
       path: "extra/system_vendor/bios_version"


### PR DESCRIPTION
Only PowerEdge R630s are present in the alt-1 system. The conditions
will need updating if this is cherry-picked to production.