### PR TITLE
Deploy Monasca Grafana

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -119,6 +119,10 @@ kolla_build_blocks:
     # The Swarm Fedora-atomic ironic driver is currently in development, so
     # pull in an pike-based version of magnum with this change applied.
     RUN pip install -U --no-deps git+https://github.com/stackhpc/magnum.git@stackhpc/pike
+  grafana_footer: |
+    RUN grafana-cli plugins install monasca-datasource
+    # Install plugin for Gantt charts
+    RUN grafana-cli plugins install natel-discrete-panel
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:
@@ -127,6 +131,10 @@ kolla_build_blocks:
 # most commonly packages. The operation should be one of override, append or
 # remove. The value should be a list.
 #kolla_build_customizations:
+kolla_build_customizations:
+   # Use our own repo server to install the monasca-grafana fork
+   base_yum_repo_files_remove:
+     - 'grafana.repo'
 
 ###############################################################################
 # Kolla-ansible inventory configuration.
@@ -196,6 +204,7 @@ kolla_enable_barbican: True
 #kolla_enable_freezer:
 #kolla_enable_gnocchi:
 #kolla_enable_grafana:
+kolla_enable_grafana: True
 #kolla_enable_haproxy:
 #kolla_enable_heat:
 #kolla_enable_horizon:

--- a/etc/kayobe/kolla/config/grafana.ini
+++ b/etc/kayobe/kolla/config/grafana.ini
@@ -1,0 +1,15 @@
+[auth.keystone]
+enabled = true
+auth_url = {% raw %}{{ keystone_internal_url }}
+{% endraw %}
+v3 = false
+default_domain = default
+default_role = Viewer
+global_admin_roles =
+admin_roles = admin
+editor_roles = _member_
+read_editor_roles =
+viewer_roles =
+; Can't get this to work due to IP "SANs" ??
+verify_ssl_cert = false
+root_ca_pem_file =

--- a/etc/kayobe/kolla/kolla-build.conf
+++ b/etc/kayobe/kolla/kolla-build.conf
@@ -1,0 +1,5 @@
+[DEFAULT]
+# This is the Docker integration bridge IP and the port of an out of band
+# repo server listening on it.
+# TODO(dszumski): Deploy the repo server with Kayobe?
+rpm_setup_config = http://172.17.0.1:4121/Monasca-Extras/monasca-extras.repo


### PR DESCRIPTION
This is the same commit which went into alt-1.

This removes the vanilla grafana.repo from the Kolla base image,
splices in our own out-of-band repo server, and installs
the Monasca Grafana fork from there.

This commit also installs the Monasca datasource plugin, and the
Natel energy discrete panel for plotting SLURM Gantt charts.