### PR TITLE
Feature/configure grafana

### DIFF
--- a/etc/kayobe/grafana.yml
+++ b/etc/kayobe/grafana.yml
@@ -15,6 +15,7 @@ grafana_monitoring_node_dashboard_repo:
 
 # Dashboard repo version. Optional, defaults to 'HEAD'.
 #grafana_monitoring_node_dashboard_repo_version:
+grafana_monitoring_node_dashboard_repo_version: master
 
 # Path to which Grafana dashboards will be cloned to a monitoring node
 #grafana_monitoring_node_dashboard_repo_checkout_path: "{{ source_checkout_path ~ '/grafana-dashboards' }}"

--- a/etc/kayobe/grafana.yml
+++ b/etc/kayobe/grafana.yml
@@ -4,7 +4,8 @@
 
 # Grafana local admin user name. If you are deploying Monasca Grafana this
 # should not conflict with an OpenStack user name.
-#grafana_local_admin_user_name:
+#grafana_local_admin_user_name: "admin"
+grafana_local_admin_user_name: "grafana-admin"
 
 # Path to git repo containing Grafana dashboards. Eg.
 # https://github.com/stackhpc/grafana-reference-dashboards.git
@@ -12,17 +13,25 @@
 grafana_monitoring_node_dashboard_repo:
   "https://github.com/stackhpc/grafana-reference-dashboards.git"
 
+# Dashboard repo version. Optional, defaults to 'HEAD'.
+#grafana_monitoring_node_dashboard_repo_version:
+
 # Path to which Grafana dashboards will be cloned to a monitoring node
+#grafana_monitoring_node_dashboard_repo_checkout_path: "{{ source_checkout_path ~ '/grafana-dashboards' }}"
+
+# The path, relative to the grafana_monitoring_node_dashboard_repo_checkout_path
+# containing the dashboards. Eg. /prometheus/control_plane
 #grafana_monitoring_node_dashboard_repo_path:
+grafana_monitoring_node_dashboard_repo_path: "/monasca/control_plane"
 
 # The Grafana organisation for the control plane. Note that for Monasca
 # Grafana with domain support the format is:
 # organisation_name@openstack_domain
-#grafana_control_plane_organisation:
+#grafana_control_plane_organisation: "control_plane"
 grafana_control_plane_organisation: "monasca@default"
 
-# A list of datasources to configure. See the stackhpc.grafana-conf role
-# for a list of supported datasources. Example:
+# A dict of datasources to configure. See the stackhpc.grafana-conf role
+# for all supported datasources. Example:
 #
 # grafana_datasources:
 #   monasca_api:
@@ -49,10 +58,5 @@ grafana_datasources:
     port: 9200
     host: 10.60.253.3
     project_id: "1c8ec8e9fdc64895ada3c91af6bef423"
-
-# The path, relative to the grafana_monitoring_node_dashboard_repo_path
-# containing the dashboards. Eg. /prometheus/control_plane
-#grafana_monitoring_node_dashboard_path:
-grafana_monitoring_node_dashboard_path: "/monasca/control_plane"
 
 ###############################################################################

--- a/etc/kayobe/grafana.yml
+++ b/etc/kayobe/grafana.yml
@@ -1,0 +1,58 @@
+---
+###############################################################################
+# Grafana configuration.
+
+# Grafana local admin user name. If you are deploying Monasca Grafana this
+# should not conflict with an OpenStack user name.
+#grafana_local_admin_user_name:
+
+# Path to git repo containing Grafana dashboards. Eg.
+# https://github.com/stackhpc/grafana-reference-dashboards.git
+#grafana_monitoring_node_dashboard_repo:
+grafana_monitoring_node_dashboard_repo:
+  "https://github.com/stackhpc/grafana-reference-dashboards.git"
+
+# Path to which Grafana dashboards will be cloned to a monitoring node
+#grafana_monitoring_node_dashboard_repo_path:
+
+# The Grafana organisation for the control plane. Note that for Monasca
+# Grafana with domain support the format is:
+# organisation_name@openstack_domain
+#grafana_control_plane_organisation:
+grafana_control_plane_organisation: "monasca@default"
+
+# A list of datasources to configure. See the stackhpc.grafana-conf role
+# for a list of supported datasources. Example:
+#
+# grafana_datasources:
+#   monasca_api:
+#     port: 8082
+#     host: monasca-api
+#   monasca_log_api:
+#     port: 5607
+#     host: monasca-log-api
+#   elasticsearch:
+#     port: 9200
+#     host: monasca-elasticsearch
+#     project_id: "some_id"
+#
+#grafana_datasources:
+grafana_datasources:
+  # TODO: Change to VIP when these are behind HAProxy
+  monasca_api:
+    port: 8082
+    host: 10.60.253.3
+  monasca_log_api:
+    port: 5607
+    host: 10.60.253.3
+  elasticsearch:
+    port: 9200
+    host: 10.60.253.3
+    project_id: "1c8ec8e9fdc64895ada3c91af6bef423"
+
+# The path, relative to the grafana_monitoring_node_dashboard_repo_path
+# containing the dashboards. Eg. /prometheus/control_plane
+#grafana_monitoring_node_dashboard_path:
+grafana_monitoring_node_dashboard_path: "/monasca/control_plane"
+
+###############################################################################

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -126,7 +126,13 @@ kolla_build_blocks:
     # Bring in hack to the vanilla plugin
     RUN pip install -U --no-deps git+https://github.com/stackhpc/sahara.git@stackhpc/pike
   grafana_footer: |
-    RUN grafana-cli plugins install monasca-datasource
+    # TODO: Re-enable the official plugin when #450868 is merged upstream. For now we will
+    # manually install it from git
+    # RUN grafana-cli plugins install monasca-datasource
+    RUN mkdir -p /var/lib/grafana/plugins/monasca-datasource \
+        && curl -Lo tmp.tgz https://github.com/stackhpc/monasca-grafana-datasource/tarball/log-query-api \
+        && tar zxvf tmp.tgz -C /var/lib/grafana/plugins/monasca-datasource --strip-components=1 \
+        && rm tmp.tgz
     # Install plugin for Gantt charts
     RUN grafana-cli plugins install natel-discrete-panel
 

--- a/etc/kayobe/kolla/config/grafana.ini
+++ b/etc/kayobe/kolla/config/grafana.ini
@@ -1,12 +1,3 @@
-[security]
-; If an OpenStack user with the same name as the admin user logs into
-; Grafana it overwrites user data in the Grafana database, breaking
-; the local admin account, and preventing admin API calls to Grafana. To
-; reduce the chance of this happening we rename the local admin user here.
-; Note that this only affects the Monasca fork of Grafana.
-;admin_user = admin
-admin_user = grafana_admin
-
 [auth.keystone]
 enabled = true
 auth_url = {% raw %}{{ keystone_internal_url }}


### PR DESCRIPTION
Monasca isn't configured on the alt-1 controller, but this is useful for testing against Grafana which is deployed on it.