### PR TITLE
Enable Kafka

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -135,6 +135,11 @@ kolla_build_blocks:
         && rm tmp.tgz
     # Install plugin for Gantt charts
     RUN grafana-cli plugins install natel-discrete-panel
+  kafka_version: |
+    # This is the most recent version of Kafka that Monasca currently supports
+    ENV kafka_url=https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz
+    ENV kafka_pkg_sha512sum=818a821877436bbb9698a32afeb299bc569985a6b712179a9882bf1a10edfdb4992519ba39c1d7499144650b30781fc943a4d5d15b8d5916a4c1a5e542d9b956
+
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:
@@ -239,6 +244,8 @@ kolla_enable_grafana: True
 kolla_enable_influxdb: True
 #kolla_enable_ironic:
 #kolla_enable_iscsid:
+#kolla_enable_kafka:
+kolla_enable_kafka: True
 #kolla_enable_karbor:
 #kolla_enable_kibana:
 kolla_enable_kibana: True
@@ -281,6 +288,7 @@ kolla_enable_sahara: True
 #kolla_enable_trove:
 #kolla_enable_vmtp:
 #kolla_enable_watcher:
+#kolla_enable_zookeeper:
 #kolla_enable_zun:
 
 ###############################################################################


### PR DESCRIPTION
This implicitly enables Zookeeper. The most recent version of Kafka
supported by Monasca is used.