### PR TITLE
Enable Kafka on the monitoring server

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -130,6 +130,15 @@ kolla_build_blocks:
     # Install plugin for Gantt charts
     RUN grafana-cli plugins install natel-discrete-panel
     RUN grafana-cli plugins install vonage-status-panel
+  kafka_version: |
+    # TODO(dszumski) This is the most recent version of Kafka that Monasca
+    # currently supports but we need to upgrade Monasca services before we
+    # can use it. Until then continue to use the same version as provided
+    # by the LXC container.
+    # ENV kafka_url=https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz
+    # ENV kafka_pkg_sha512sum=818a821877436bbb9698a32afeb299bc569985a6b712179a9882bf1a10edfdb4992519ba39c1d7499144650b30781fc943a4d5d15b8d5916a4c1a5e542d9b956
+    ENV kafka_url=https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.10-0.8.2.2.tgz
+    ENV kafka_pkg_sha512sum=03978c4e82257eb36cc4c80c82c8e22a18a4546fd857b4fa34b089674960894321efb9c461229944b2b148c32c0cc4ec8a5d4c01ea8aee67ed9bedcf632a6b0d
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:
@@ -222,6 +231,8 @@ kolla_enable_grafana: True
 kolla_enable_influxdb: True
 #kolla_enable_ironic:
 #kolla_enable_iscsid:
+#kolla_enable_kafka:
+kolla_enable_kafka: True
 #kolla_enable_karbor:
 #kolla_enable_kibana:
 kolla_enable_kibana: True
@@ -264,6 +275,7 @@ kolla_enable_sahara: True
 #kolla_enable_trove:
 #kolla_enable_vmtp:
 #kolla_enable_watcher:
+#kolla_enable_zookeeper:
 #kolla_enable_zun:
 
 ###############################################################################

--- a/etc/kayobe/kolla/config/kafka.server.properties
+++ b/etc/kayobe/kolla/config/kafka.server.properties
@@ -1,0 +1,12 @@
+{% raw %}
+port = {{ kafka_port }}
+host.name= {{ api_interface_address }}
+{% endraw %}
+listeners = not_used
+{% raw %}
+{% for host in groups['kafka'] -%}
+{% if hostvars[host]['ansible_hostname'] == ansible_hostname -%}
+broker.id = {{ loop.index }}
+{%- endif %}
+{%- endfor %}
+{% endraw %}

--- a/etc/kayobe/kolla/inventory/overcloud-components.j2
+++ b/etc/kayobe/kolla/inventory/overcloud-components.j2
@@ -39,6 +39,12 @@ control
 [influxdb:children]
 monitoring
 
+###### CUSTOMISED #######
+[kafka:children]
+#control
+monitoring
+#########################
+
 [karbor:children]
 control
 
@@ -208,3 +214,9 @@ control
 
 [skydive:children]
 monitoring
+
+###### CUSTOMISED #######
+[zookeeper:children]
+#control
+monitoring
+#########################


### PR DESCRIPTION
This uses the version of Kafka currently provided by LXC, as
more recent versions require Monasca services to be upgraded. When
the Monasca services are upgraded we can go back to the listeners
field and automatic broker id generation.

The host.name field is set to the API IP address, because
otherwise it defaults to the hostname, and since DNS is not
configured the Monasca-API can't talk to it.

This implicitly enables Zookeeper.