### PR TITLE
Use legacy InfluxDB version

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -151,6 +151,8 @@ kolla_build_customizations:
    # Use our own repo server to install the monasca-grafana fork
    base_yum_repo_files_remove:
      - 'grafana.repo'
+   influxdb_packages_override:
+     - 'influxdb-0.10.3-1'
 
 ###############################################################################
 # Kolla-ansible inventory configuration.


### PR DESCRIPTION
Until the Monasca LXC services are upgraded use the same
version of InfluxDB LXC provided. After they are upgraded
they should support up to v1.1.0 (later versions have
not been tested).