### PR TITLE
(WIP) set nic-firmware attribute for mellanox connectx-4

### DIFF
--- a/etc/kayobe/inspector.yml
+++ b/etc/kayobe/inspector.yml
@@ -120,6 +120,18 @@ inspector_rules_extra:
     - action: "set-attribute"
       path: "extra/system_vendor/bios_version"
       value: "2.6.0"
+  - description: "Set the expected firmware version for Mellanox ConnectX-4"
+    conditions:
+    - field: "data://inventory.interfaces[*].product"
+      op: "matches"
+      value: "^(0x1013)$"
+    - field: "data://inventory.interfaces[*].vendor"
+      op: "matches"
+      value: "^(0x15B3)$"
+    actions:
+      - action: "extend-attribute"
+      - path: "extra/nic_firmware"
+      - value: '[{"vendor_id": "15B3", "device_id": "1013", "firmware_version": "12.20.1010"}]'
 
 # List of all ironic inspector rules.
 #inspector_rules:


### PR DESCRIPTION
Was unsure how to test this... I tried a `kayobe overcloud hardware inspect`:

```
(kayobe) [will@dev-director kayobe]$ kayobe overcloud hardware inspect

PLAY [Ensure the overcloud nodes' hardware is inspected] *******************************************************************************

TASK [Check the ironic node's initial provision state] *********************************************************************************
fatal: [sv-b16-u23 -> {{ hostvars[seed_host].ansible_host | default(seed_host) }}]: FAILED! => {"changed": false, "cmd": ["docker", "exec", "bifrost_deploy", "bash", "-c", ". env-vars && export OS_URL=$IRONIC_URL && export OS_TOKEN=$OS_AUTH_TOKEN && export BIFROST_INVENTORY_SOURCE=ironic && ansible baremetal --connection local --inventory /etc/bifrost/inventory/ -e @/etc/bifrost/bifrost.yml -e @/etc/bifrost/dib.yml --limit sv-b16-u23 -m command -a \"openstack baremetal node show {{ inventory_hostname }} -f value -c provision_state\""], "delta": "0:00:00.686313", "end": "2018-03-27 13:22:55.637427", "failed": true, "rc": 1, "start": "2018-03-27 13:22:54.951114", "stderr": "ERROR! the file_name '/etc/bifrost/bifrost.yml' does not exist, or is not readable", "stderr_lines": ["ERROR! the file_name '/etc/bifrost/bifrost.yml' does not exist, or is not readable"], "stdout": "", "stdout_lines": []}
```

Probably haven't configured kayobe correctly. Any suggestions would be welcome.