### PR TITLE
Switch to Fernet token format

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -1,3 +1,5 @@
 ---
 # Add extra Kolla global configuration here.
 rabbitmq_monitoring_user: "monitoring"
+
+keystone_token_provider: "fernet"


### PR DESCRIPTION
Configure Keystone's token driver for Fernet[0] instead of UUID.  The latter has been deprecated for some time now, and will be removed as of the 'Rocky' release of OpenStack[1].  Fernet has been the default since 'Ocata'.

NB:  This change is prompted by a bug in Keystone affecting federated users and their group mapping[2].

[0] https://docs.openstack.org/keystone/queens/admin/identity-fernet-token-faq.html
[1] https://review.openstack.org/#/c/543060/
[2] https://bugs.launchpad.net/keystone/+bug/1758460