### PR TITLE
Remove 'v3' from EGI Check-in redirect URLs

### DIFF
--- a/etc/kayobe/kolla/config/keystone/wsgi-keystone.conf
+++ b/etc/kayobe/kolla/config/keystone/wsgi-keystone.conf
@@ -28,19 +28,19 @@ TraceEnable off
     OIDCClientID {{ secrets_egi_client_id }}
     OIDCClientSecret {{ secrets_egi_client_secret }}
     OIDCCryptoPassphrase {{ secrets_egi_crypto_passphrase }}
-    OIDCRedirectURI http://{% raw %}{{ kolla_external_fqdn }}:{{ keystone_public_port }}{% endraw %}/v3/auth/OS-FEDERATION/websso/oidc/redirect
+    OIDCRedirectURI http://{% raw %}{{ kolla_external_fqdn }}:{{ keystone_public_port }}{% endraw %}/auth/OS-FEDERATION/websso/oidc/redirect
 
     # OAuth for CLI access
     OIDCOAuthIntrospectionEndpoint  https://aai-dev.egi.eu/oidc/introspect
     OIDCOAuthClientID {{ secrets_egi_client_id }}
     OIDCOAuthClientSecret {{ secrets_egi_client_secret }}
 
-    <Location ~ "/v3/auth/OS-FEDERATION/websso/oidc">
+    <Location ~ "/auth/OS-FEDERATION/websso/oidc">
             AuthType  openid-connect
             Require   valid-user
     </Location>
 
-    <Location ~ "/v3/OS-FEDERATION/identity_providers/egi.eu/protocols/oidc/auth">
+    <Location ~ "/OS-FEDERATION/identity_providers/egi.eu/protocols/oidc/auth">
             Authtype oauth20
             Require   valid-user
     </Location>


### PR DESCRIPTION
The 'v3' isn't part of the identity service definition in Keystone's service catalogue / the corresponding K-A value for `keystone_public_url` (which is used by Horizon), and so needs to be removed in order for these redirects to function.