### PR TITLE
Only clean metadata before node deployment

### DIFF
--- a/etc/kayobe/kolla/config/ironic/ironic-conductor.conf
+++ b/etc/kayobe/kolla/config/ironic/ironic-conductor.conf
@@ -2,3 +2,16 @@
 # Enable automated cleaning. To save time this uses ATA secure erase when
 # supported.
 automated_clean=true
+
+[deploy]
+# Effectively disable shred. This is to workaround the cleaning times on
+# the Storage-A node where shred takes ~29 hours per drive to complete.
+# The problem is exacerbated as the shreds are done sequentially.
+# See: https://storyboard.openstack.org/#!/story/2001780
+# When secure erase fails or is not available, we fall back to cleaning
+# the metadata only i.e partition tables, filesystem signatures, etc.
+shred_random_overwrite_iterations = 0
+shred_final_overwrite_with_zeros = false
+# Workaround SSD secure erase failures
+# See: https://storyboard.openstack.org/#!/story/2001763
+continue_if_disk_secure_erase_fails = true


### PR DESCRIPTION
At the moment we have several problems cleaning the disks on P3:

- long scrubbing times for the storage-A node (rotating disks)
- secure erase failures on multiple nodes with INTEL SSDSC2BX016T4R. I have noticed these on the storage B nodes as well as the gpu nodes. The maintenance reason will typically look like:

```
| maintenance_reason | Agent returned error for clean step {u'priority': 10, u'interface': u'deploy', u'reboot_requested': False, u'abortable': True, u'step': u'erase_devices'} on node 6c819315-a655-4718-9b52-4e8252a8213f : {u'message': u'Clean step failed: Error performing clean_step erase_devices: No HardwareManager found to handle method: Could not find method: erase_block_device', u'code': 500, u'type': u'CleaningError', u'details': u'Error performing clean_step erase_devices: No HardwareManager found to handle method: Could not find method: erase_block_device'}. |
```

This happens as the GenericHardwareManager throws an `IncompatibleHardwareError` if secure erase fails. Ironic Python Agent will then look for another hardware manager to handle to the `erase_block_device` cleaning step; no such manager exists.

This change effectively disables shredding by setting the iterations to 0 and removing the zero pass. This addresses the issue with the long scrub times. It also causes an effective fallback to metadata-only erase if secure erase fails.

I thought this would serve as a good place to discuss the disk cleaning strategy.

# relevant bug reports
- [the `continue_if_disk_secure_erase_fails` option is too broad to be useful](https://storyboard.openstack.org/#!/story/2001761)
- [GenericHardwareManager passes wrong password to `hdparm --security-unlock`](https://storyboard.openstack.org/#!/story/2001762)
- [GenericHardwareManager doesn't perform a secure_erase when it could](https://storyboard.openstack.org/#!/story/2001763)
- [the erase_devices cleaning step takes a prohibitively long period of time with large number of disks](https://storyboard.openstack.org/#!/story/2001780)