### PR TITLE
Manage Infiniband via neutron (alt-1)

### DIFF
--- a/etc/kayobe/inspector.yml
+++ b/etc/kayobe/inspector.yml
@@ -25,6 +25,7 @@
 inspector_processing_hooks_extra:
   - system_name_llc
   - system_name_physnet
+  - ib_physnet
   - extra_hardware
 
 # List of of additional inspector processing plugins.

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -108,6 +108,10 @@ kolla_build_blocks:
     # supports source builds. Install a locally modified version with a fix for
     # Dell switches until it is released.
     RUN pip install git+https://github.com/stackhpc/networking-generic-switch@stackhpc/pike
+    # Install a locally modified version of networking-mlnx with support for
+    # disabling the SDN controller sync mechanism in the mlnx_sdn_assist
+    # driver. This allows us to bind to flat Infiniband networks.
+    RUN pip install git+https://github.com/stackhpc/networking-mlnx@cauterise-sdn-client
   ironic_inspector_footer: |
     # Install our custom inspector plugins.
     RUN pip install stackhpc-inspector-plugins

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -112,6 +112,12 @@ kolla_build_blocks:
     # disabling the SDN controller sync mechanism in the mlnx_sdn_assist
     # driver. This allows us to bind to flat Infiniband networks.
     RUN pip install git+https://github.com/stackhpc/networking-mlnx@cauterise-sdn-client
+  ironic_base_footer: |
+    # Pull in Moshe's fix for IB ports to ensure they don't need
+    # local-link-connection information:
+    # https://review.openstack.org/#/c/548396. This can be removed once the
+    # aforementioned fix is included in a pike series release of ironic.
+    RUN pip install -U --no-deps git+https://github.com/openstack/ironic@stable/pike
   ironic_inspector_footer: |
     # Install our custom inspector plugins.
     RUN pip install stackhpc-inspector-plugins

--- a/etc/kayobe/kolla/config/neutron/ml2_conf.ini
+++ b/etc/kayobe/kolla/config/neutron/ml2_conf.ini
@@ -1,2 +1,5 @@
 [ml2]
 physical_network_mtus = {{ ilab_physical_network }}:{{ 'ilab' | net_mtu }}
+
+[sdn]
+physical_networks = {{ alaska_lln_physical_network }}

--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -119,6 +119,9 @@ alaska_cp_physical_network: physnet1
 alaska_bdn_vlan: 8
 alaska_bdn_physical_network: physnet2
 
+# Low Latency Network (LLN) - Infiniband.
+alaska_lln_physical_network: physnet3
+
 ###############################################################################
 # Network virtual patch link configuration.
 

--- a/etc/kayobe/neutron.yml
+++ b/etc/kayobe/neutron.yml
@@ -6,6 +6,10 @@
 # defaults will be used.
 #kolla_neutron_ml2_mechanism_drivers:
 kolla_neutron_ml2_mechanism_drivers:
+  # Use the Mellanox SDN assist mechanism driver for binding ports on a flat IB
+  # network. The driver has been modified to avoid synchronising state to an
+  # SDN controller.
+  - mlnx_sdn_assist
   - openvswitch
   - genericswitch
 


### PR DESCRIPTION
Supports only flat IB networks, no partitions.

* Enable the mlnx_sdn_assist ML2 mech driver, cauterised to avoid calls to NEO.
* Use the stable/pike branch for ironic to pull in a relevant fix.
* Enable the ib_physnet inspector plugin to apply a physnet to IB ports.