### PR TITLE
Add policy overrides for project-wide access to Magnum clusters

### DIFF
--- a/etc/kayobe/kolla/config/magnum/policy.json
+++ b/etc/kayobe/kolla/config/magnum/policy.json
@@ -1,0 +1,3 @@
+{
+    "certificate:get": "rule:admin_or_owner or rule:cluster_user"
+}

--- a/etc/kayobe/kolla/config/magnum/policy.yaml
+++ b/etc/kayobe/kolla/config/magnum/policy.yaml
@@ -1,0 +1,4 @@
+# Retrieve CA information about the given bay/cluster.
+# GET  /v1/certificates/{bay_uuid/cluster_uuid}
+# All members of a project can get the certs and access the cluster
+"certificate:get": "rule:admin_or_owner or rule:cluster_user"

--- a/etc/kayobe/kolla/config/magnum/policy.yaml
+++ b/etc/kayobe/kolla/config/magnum/policy.yaml
@@ -1,4 +1,0 @@
-# Retrieve CA information about the given bay/cluster.
-# GET  /v1/certificates/{bay_uuid/cluster_uuid}
-# All members of a project can get the certs and access the cluster
-"certificate:get": "rule:admin_or_owner or rule:cluster_user"


### PR DESCRIPTION
WIP, Not tested yet - is this along the right lines and do we need to specify somewhere that there are magnum-specific configuration overrides introduced?