### PR TITLE
Magnum policy for running openstack coe cluster config also requires …

### DIFF
--- a/etc/kayobe/kolla/config/magnum/policy.json
+++ b/etc/kayobe/kolla/config/magnum/policy.json
@@ -1,3 +1,4 @@
 {
-    "certificate:get": "rule:admin_or_owner or rule:cluster_user"
+    "certificate:get": "rule:admin_or_owner or rule:cluster_user",
+    "certificate:create": "rule:admin_or_owner or rule:cluster_user"
 }


### PR DESCRIPTION
…certificate:create