### PR TITLE
Install custom version of the Monasca log API and supporting library

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -127,6 +127,10 @@ kolla_build_blocks:
   magnum_conductor_footer: |
     # This branch fixes k8s FailedNodeAllocatableEnforcement warning
     RUN pip install -U --no-deps git+https://github.com/stackhpc/magnum@stackhpc/queens
+  monasca_log_api_footer: |
+    # Support for the log query API isn't yet merged upstream
+    RUN pip install -U --no-deps git+https://github.com/stackhpc/monasca-common@2.10.0 \
+        && pip install -U --no-deps git+https://github.com/stackhpc/monasca-log-api@stackhpc/log-query-api
   sahara_api_footer: |
     # Bring in hack to the vanilla plugin
     RUN pip install -U --no-deps git+https://github.com/stackhpc/sahara.git@stackhpc/pike


### PR DESCRIPTION
We can remove this when support is merged upstream.

Still testing..