### PR TITLE
Install custom version of the Monasca log API and supporting library

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -127,6 +127,10 @@ kolla_build_blocks:
   magnum_conductor_footer: |
     # This branch fixes k8s FailedNodeAllocatableEnforcement warning
     RUN pip install -U --no-deps git+https://github.com/stackhpc/magnum@stackhpc/queens
+  monasca_log_api_footer: |
+    # Support for the log query API isn't yet merged upstream
+    RUN pip install -U --no-deps git+https://github.com/stackhpc/monasca-common@2.10.0 \
+        && pip install -U --no-deps git+https://github.com/stackhpc/monasca-log-api@stackhpc/log-query-api
   grafana_footer: |
     # TODO: Re-enable the official plugin when #450868 is merged upstream. For now we will
     # manually install it from git


### PR DESCRIPTION
We can remove this when support is merged upstream.

Still testing..