### PR TITLE
Update the OIDC scope to include additional claims issued by EGI

### DIFF
--- a/etc/kayobe/kolla/config/keystone/wsgi-keystone.conf
+++ b/etc/kayobe/kolla/config/keystone/wsgi-keystone.conf
@@ -24,6 +24,7 @@ TraceEnable off
     OIDCClaimPrefix "OIDC-"
     OIDCClaimDelimiter ;
     OIDCScope "openid"
+    OIDCScope "openid profile email refeds_edu"
     OIDCProviderMetadataURL https://aai-dev.egi.eu/oidc/.well-known/openid-configuration
     OIDCClientID {{ secrets_egi_client_id }}
     OIDCClientSecret {{ secrets_egi_client_secret }}


### PR DESCRIPTION
EGI have recently updated the Check-in service to issue claims under a wider scope than just openid.

We need to update the configuration for the Apache httpd OIDC module to handle these, so that they can be used by Keystone for mapping federated users.