### PR TITLE
Add global_physnet_mtu to neutron.conf

### DIFF
--- a/etc/kayobe/kolla/config/neutron.conf
+++ b/etc/kayobe/kolla/config/neutron.conf
@@ -1,2 +1,4 @@
 [DEFAULT]
 dns_domain = alaskalocal.
+# This must be greater or equal to all per-physnet MTUs.
+global_physnet_mtu = 9000


### PR DESCRIPTION
Without this, networks with an MTU > 1500 cannot be deleted, even if they are
on a physical network listed in [ml2] physical_network_mtus.