### PR TITLE
Ensure Keystone containers are deployed from a Queens image

### DIFF
--- a/etc/kayobe/kolla/config/keystone/wsgi-keystone.conf
+++ b/etc/kayobe/kolla/config/keystone/wsgi-keystone.conf
@@ -23,7 +23,6 @@ TraceEnable off
     OIDCResponseType "code"
     OIDCClaimPrefix "OIDC-"
     OIDCClaimDelimiter ;
-    OIDCScope "openid"
     OIDCScope "openid profile email refeds_edu"
     OIDCProviderMetadataURL https://aai-dev.egi.eu/oidc/.well-known/openid-configuration
     OIDCClientID {{ secrets_egi_client_id }}

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -3,6 +3,7 @@
 rabbitmq_monitoring_user: "monitoring"
 
 keystone_token_provider: "fernet"
+keystone_tag: 6.0.0.0
 
 magnum_tag: 6.0.0.0
 


### PR DESCRIPTION
Save confusion by ensuring that the right version of Keystone (Queens)
is deployed by default via Kayobe.

This commit also fixes a typo (duplicate option) related to OpenID
Connect.