### PR TITLE
Suffix the URL that Horizon uses for Keystone

### DIFF
--- a/etc/kayobe/kolla/config/horizon/local_settings
+++ b/etc/kayobe/kolla/config/horizon/local_settings
@@ -191,7 +191,7 @@ AVAILABLE_REGIONS = [
 
 OPENSTACK_HOST = "{{ kolla_internal_fqdn }}"
 
-OPENSTACK_KEYSTONE_URL = "{{ keystone_public_url }}"
+OPENSTACK_KEYSTONE_URL = "{{ keystone_public_url }}/v3"
 OPENSTACK_KEYSTONE_DEFAULT_ROLE = "{{ keystone_default_user_role }}"
 
 # Enables keystone web single-sign-on if set to True.


### PR DESCRIPTION
This is required for certain URLs that Horizon builds when handing off
to Keystone, notably redirection to the endpoints related to EGI
Check-in.