### PR TITLE
Workaround for IPA DIB failing with pip > 10

### DIFF
--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -42,7 +42,11 @@ ipa_build_dib_elements_extra:
 
 # Dictionary of default environment variables to provide to Diskimage Builder
 # (DIB) during IPA image build.
-#ipa_build_dib_env_default:
+ipa_build_dib_env_default:
+  # This is to workaround the fact that pip > 10 will produce an error if you try and
+  # uninstall a distuils installed package. Previous versions would remove the
+  # metadata only -  leaving the code intact, see: https://bugs.launchpad.net/diskimage-builder/+bug/1768135
+  DIB_INSTALLTYPE_pip_and_virtualenv: package
 
 # Dictionary of additional environment variables to provide to Diskimage
 # Builder (DIB) during IPA image build.

--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -42,15 +42,16 @@ ipa_build_dib_elements_extra:
 
 # Dictionary of default environment variables to provide to Diskimage Builder
 # (DIB) during IPA image build.
-ipa_build_dib_env_default:
+#ipa_build_dib_env_default:
+
+# Dictionary of additional environment variables to provide to Diskimage
+# Builder (DIB) during IPA image build.
+ipa_build_dib_env_extra:
   # This is to workaround the fact that pip > 10 will produce an error if you try and
   # uninstall a distuils installed package. Previous versions would remove the
   # metadata only -  leaving the code intact, see: https://bugs.launchpad.net/diskimage-builder/+bug/1768135
   DIB_INSTALLTYPE_pip_and_virtualenv: package
 
-# Dictionary of additional environment variables to provide to Diskimage
-# Builder (DIB) during IPA image build.
-#ipa_build_dib_env_extra:
 
 # Dictionary of environment variables to provide to Diskimage Builder (DIB)
 # during IPA image build.


### PR DESCRIPTION
Symptom:

```
TASK [stackhpc.os-images : Fail if any images failed to build] **********************
failed: [sv-b16-u23] (item=[{u'elements': [u'centos7', u'enable-serial-console', u'ironic-agent', u'ipa-extra-hardware', u'mellanox', u'stackhpc-ipa-hardware-managers'], u'type': u'raw', u'name': u'ipa', u'env': {u'DIB_REPOREF': u'refs/tags/stackhpc/2.2.3.1', u'DIB_REPOLOCATION': u'https://github.com/stackhpc/ironic-python-agent'}}, 1]) => {"failed": true, "item": [{"elements": ["centos7", "enable-serial-console", "ironic-agent", "ipa-extra-hardware", "mellanox", "stackhpc-ipa-hardware-managers"], "env": {"DIB_REPOLOCATION": "https://github.com/stackhpc/ironic-python-agent", "DIB_REPOREF": "refs/tags/stackhpc/2.2.3.1"}, "name": "ipa", "type": "raw"}, 1], "msg": "Image ipa failed to build. See ipa.stdout and ipa.stderr in /opt/kayobe/images/ipa.\n"}
```