### PR TITLE
Bump kolla_openstack_release

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -15,7 +15,7 @@ kolla_source_url: https://github.com/stackhpc/kolla.git
 
 # Version (branch, tag, etc.) of Kolla source code repository if type is
 # 'source'.
-kolla_source_version: refs/tags/stackhpc/5.0.3.2
+kolla_source_version: refs/tags/stackhpc/5.0.3.3
 
 # Path to virtualenv in which to install kolla.
 #kolla_venv:
@@ -70,7 +70,7 @@ kolla_ansible_source_version: refs/tags/stackhpc/5.0.3.1
 #kolla_docker_registry_password:
 
 # Kolla OpenStack release version. This should be a Docker image tag.
-#kolla_openstack_release:
+kolla_openstack_release: 5.0.3.3-1
 
 # Dict mapping names of sources to their definitions for
 # kolla_install_type=source. See kolla.common.config for details.


### PR DESCRIPTION
The idea is you bump the release suffix if you make modifications that don't rely on a newer version of kolla. So the next version with the same kolla release would be: 5.0.3.3-2.