### PR TITLE
Remove the scheduler hook from ironic inspector processing pipeline

### DIFF
--- a/etc/kayobe/inspector.yml
+++ b/etc/kayobe/inspector.yml
@@ -19,6 +19,14 @@
 
 # List of of default inspector processing plugins.
 #inspector_processing_hooks_default:
+# Remove scheduler from default processing hooks.
+inspector_processing_hooks_default:
+  - ramdisk_error
+  - validate_interfaces
+  - capabilities
+  - pci_devices
+  - local_link_connection
+  - lldp_basic
 
 # List of of additional inspector processing plugins.
 #inspector_processing_hooks_extra:


### PR DESCRIPTION
This applies scheduling properties to nodes during inspection. We don't want this as it could mean that VMs get scheduled to bare metal nodes.


Taken from: https://github.com/stackhpc/eod-kayobe-config/commit/f93de19a0c0b428abe719720e89307dc5c0c56ae