### PR TITLE
Use the same base_path variable for production and alt-1

### DIFF
--- a/etc/kayobe/globals.yml
+++ b/etc/kayobe/globals.yml
@@ -12,7 +12,6 @@
 
 # Base path for kayobe state on remote hosts.
 #base_path:
-base_path: "/opt/alaska/prod"
 
 # Path in which to cache downloaded images on remote hosts.
 #image_cache_path:


### PR DESCRIPTION
This affects where virtualenvs, images, source code, and other things are
created.