### PR TITLE
Disable max series and values per tag settings in InfluxDB

### DIFF
--- a/etc/kayobe/kolla/config/influxdb.conf
+++ b/etc/kayobe/kolla/config/influxdb.conf
@@ -1,0 +1,57 @@
+{% raw %}
+reporting-disabled = false
+[logging]
+  level = "info"
+  file = "/var/log/kolla/influxdb/influxdb.log"
+[meta]
+  dir = "/var/lib/influxdb/meta"
+  retention-autocreate = true
+  logging-enabled = true
+[data]
+  dir = "/var/lib/influxdb/data"
+  wal-dir = "/var/lib/influxdb/wal"
+  wal-logging-enabled = true
+  data-logging-enabled = true
+  max-series-per-database = 0
+  max-values-per-tag = 0
+[coordinator]
+  write-timeout = "10s"
+  max-concurrent-queries = 0
+  query-timeout = "0s"
+  max-select-point = 0
+  max-select-series = 0
+  max-select-buckets = 0
+[retention]
+  enabled = true
+  check-interval = "30m"
+[shard-precreation]
+  enabled = true
+  check-interval = "10m"
+  advance-period = "30m"
+[monitor]
+  store-enabled = true
+  store-database = "_internal"
+  store-interval = "10s"
+[admin]
+  enabled = true
+  bind-address = "{{ api_interface_address }}:{{ influxdb_admin_port }}"
+  https-enabled = false
+[http]
+  enabled = true
+  bind-address = "{{ api_interface_address }}:{{ influxdb_http_port }}"
+  auth-enabled = false
+  log-enabled = true
+  write-tracing = false
+  pprof-enabled = false
+  https-enabled = false
+  max-row-limit = 10000
+[[graphite]]
+  enabled = false
+[[opentsdb]]
+  enabled = false
+[[udp]]
+  enabled = false
+[continuous_queries]
+  log-enabled = true
+  enabled = true
+{% endraw %}


### PR DESCRIPTION
Although it would be better to fix the cause, this change allows InfluxDB
to continue accepting new metrics until a better solution is cobbled
together. These limits don't appear to have been present in 0.10 from
which we recently upgraded.