### PR TITLE
Update Monasca config

### DIFF
--- a/etc/kayobe/kolla/config/monasca/log-metrics.conf
+++ b/etc/kayobe/kolla/config/monasca/log-metrics.conf
@@ -1,0 +1,100 @@
+# Provide stream processing for Monasca log metrics.
+
+input {
+    kafka {
+        zk_connect => "{% raw %}{{ monasca_zookeeper_servers }}{% endraw %}"
+        topic_id => "{% raw %}{{ monasca_transformed_logs_topic }}{% endraw %}"
+        group_id => "log-metric"
+        consumer_id => "monasca_log_metrics"
+    }
+}
+
+# Create events from specific log signatures
+filter {
+  if "Unable to attach VIF" in [log][message] {
+    mutate {
+      add_field => { "[log][dimensions][event]" => "unable_to_attach_vif" }
+    }
+  }
+
+  mutate {
+    # Make sure the special case isn't dropped because it's info level etc.
+    add_field => { "[log][dimensions][log_level]" => "error" }
+  }
+}
+
+# Drop everything we don't want to create metrics for.
+filter {
+  mutate {
+    lowercase => [ "[log][dimensions][log_level]" ]
+  }
+  if ![log][dimensions][log_level] or ![log][dimensions][programname] or [log][dimensions][log_level] in [ "debug", "trace", "info" ] {
+    drop {
+    }
+  }
+}
+
+# Construct the metric.
+
+filter {
+  # If the log line was categorised, then use that as the metric name.
+  # Otherwise, create a generic catch-all metric. We might want the
+  # generic metric to still be generated even for event-tagged logs.
+
+  if [log][dimensions][event] {
+    mutate {
+      add_field => { "[metric][name]" => "log.event.%{[log][dimensions][event]}" }
+    }
+  } else {
+    mutate {
+      add_field => { "[metric][name]" => "log.%{[log][dimensions][programname]}.%{[log][dimensions][log_level]}" }
+    }
+  }
+
+  # Create a metric structure from the log dimensions
+  mutate {
+    add_field => { "[metric][value]" => 1 }
+    rename => { "[log][dimensions]" => "[metric][dimensions]" }
+    rename => { "[metric][dimensions][Hostname]" => "[metric][dimensions][hostname]" }
+    rename => { "[metric][dimensions][programname]" => "[metric][dimensions][component]" }
+    rename => { "[log][message]" => "[metric][value_meta][logsummary]" }
+    add_field => { "[metric][dimensions][service]" => 1 }
+  }
+
+   ruby {
+     code => "event['metric']['value_meta']['logsummary'] = event['metric']['value_meta']['logsummary'][0..3]"
+   }
+
+  mutate {
+    convert => { "[metric][value]" => "float" }
+  }
+
+  # Remove dimensions which we chose to form the metric name to avoid duplication.
+  mutate {
+    remove_field => [ "[metric][dimensions][event]", "[metric][dimensions][type]", "[metric][dimensions][log_level]", "[metric][meta]" ]
+  }
+
+  # Remove dimensions which have high variability and therefore very little use as individual alerts.
+  mutate {
+    remove_field => [ "[metric][dimensions][Pid]", "[metric][dimensions][src_port]", "[metric][dimensions][src_ip]", "[metric][dimensions][dest_port]", "[metric][dimensions][dest_ip]", "[metric][dimensions][domain_id]", "[metric][dimensions][tenant_id]", "[metric][dimensions][request_id]", "[metric][dimensions][user_domain]", "[metric][dimensions][user_id]", "[metric][dimensions][tag]", "[metric][dimensions][timestamp]", "[metric][dimensions][python_module]", "[metric][dimensions][project_domain]", "[metric][dimensions][Logger]" ]
+  }
+
+  # Convert the timestamp of the event to milliseconds since epoch.
+  ruby {
+    code => "event['metric']['timestamp'] = event['@timestamp'].to_i * 1000"
+  }
+
+  # Clean up anything in the event which is not needed (including the original log) (removed creation_time from here)..
+  mutate {
+    remove_field => [  "log", "@version", "@timestamp", "tags" ]
+  }
+
+}
+
+output {
+  kafka {
+    bootstrap_servers => "{% raw %}{{ monasca_kafka_servers }}{% endraw %}"
+    topic_id => "{% raw %}{{ monasca_metrics_topic }}{% endraw %}"
+    client_id => "monasca_log_metrics"
+  }
+}

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -53,6 +53,7 @@ mariadb_tag: 6.1.0.2-1
 memcached_tag: 6.1.0.2-1
 monasca_tag: 6.1.0.2-2
 monasca_notification_tag: 6.1.0.2-4
+monasca_persister_tag: 6.1.0.3-2
 neutron_tag: 6.1.0.2-1
 nova_tag: 6.1.0.2-1
 openvswitch_tag: 6.1.0.2-1


### PR DESCRIPTION
Update Monasca persister tag to include bugfix
Add custom log metrics config file for creating metrics from logs (this overwrites default queens config to be more like the legacy LXC config).