### PR TITLE
enable nova serial console proxy

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -308,7 +308,7 @@ kolla_enable_murano: false
 #kolla_enable_neutron_agent_ha:
 #kolla_enable_neutron_bgp_dragent:
 #kolla_enable_neutron_provider_networks:
-#kolla_enable_nova_serialconsole_proxy:
+kolla_enable_nova_serialconsole_proxy: true
 #kolla_enable_octavia:
 #kolla_enable_osprofiler:
 #kolla_enable_panko:


### PR DESCRIPTION
This is required to enable the serial consoles to accessed via Horizon
when using the ipmi-socat serial console driver. See:

https://docs.openstack.org/ironic/latest/admin/console.html