### PR TITLE
Enable Designate (DNS-as-a-Service)

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -265,7 +265,7 @@ kolla_enable_barbican: True
 #kolla_enable_cinder_backend_nfs:
 #kolla_enable_cloudkitty:
 #kolla_enable_congress:
-#kolla_enable_designate:
+kolla_enable_designate: True
 #kolla_enable_elasticsearch:
 kolla_enable_elasticsearch: True
 #kolla_enable_etcd:

--- a/etc/kayobe/kolla/config/designate/designate-sink.conf
+++ b/etc/kayobe/kolla/config/designate/designate-sink.conf
@@ -1,0 +1,2 @@
+[handler:nova_fixed]
+zone_id = 01770bdc-d1cd-4967-afc1-835a585c812d

--- a/etc/kayobe/kolla/config/neutron.conf
+++ b/etc/kayobe/kolla/config/neutron.conf
@@ -1,4 +1,4 @@
 [DEFAULT]
-dns_domain = alaskalocal.
+dns_domain = alaska.local.
 # This must be greater or equal to all per-physnet MTUs.
 global_physnet_mtu = 9000

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -19,6 +19,10 @@ monasca_default_authorized_roles:
 monasca_agent_authorized_roles:
   - monasca-agent
 
+# Designate (DNSaaS) configuration
+designate_backend: "bind9"
+designate_ns_record: "sv-b16-u23.alaska.local"
+
 # Container image tags.
 # These should be allowed to change independently, as services are updated.
 


### PR DESCRIPTION
This commit includes the minimum configuration necessary to enable a deployment of Designate.