### PR TITLE
Avoid reaping Kafka connections

### DIFF
--- a/etc/kayobe/kolla/config/kafka.server.properties
+++ b/etc/kayobe/kolla/config/kafka.server.properties
@@ -1,1 +1,2 @@
 log.message.format.version=0.9.0.0
+connections.max.idle.ms = 31540000000


### PR DESCRIPTION
Kafka introduced an optimisation in 0.10+ that reaps idle socket
connections. Kafka clients were generally updated to support
closing connections before they were reaped / re-opening new ones,
however - *please sit down* - Monasca forked the kafka-python library
just before this support was added. This results in a slurry of errors
relating to closed connections from the various Monasca services using
the forked client. The simplest way to fix this problem is to turn off
the connection reaping on the broker side by setting the timeout to
an arbitrarily long time, in this case 10 years (field is a Java long).
It is difficult to backport the patch for connection reaping to the
kafka-python fork because asynchronous methods were introduced after
the Monasca fork, and are not used by Monasca. When Monasca moves to
a modern Kafka library this patch can be reverted.