### PR TITLE
Remove legacy LXC logical volume

### DIFF
--- a/etc/kayobe/monitoring.yml
+++ b/etc/kayobe/monitoring.yml
@@ -84,7 +84,6 @@ monitoring_lvm_group_data_disks:
 # List of LVM logical volumes for the data volume group.
 monitoring_lvm_group_data_lvs:
   - "{{ monitoring_lvm_group_data_lv_docker_volumes }}"
-  - "{{ monitoring_lvm_group_data_lv_lxc }}"
 
 # Docker volumes LVM backing volume.
 monitoring_lvm_group_data_lv_docker_volumes:
@@ -100,21 +99,6 @@ monitoring_lvm_group_data_lv_docker_volumes_size: 15%VG
 
 # Filesystem for docker volumes LVM backing volume. ext4 allows for shrinking.
 monitoring_lvm_group_data_lv_docker_volumes_fs: ext4
-
-# LXC LVM backing volume.
-monitoring_lvm_group_data_lv_lxc:
-  lvname: lxc
-  size: "{{ monitoring_lvm_group_data_lv_lxc_size }}"
-  create: True
-  filesystem: "{{ monitoring_lvm_group_data_lv_lxc_fs }}"
-  mount: True
-  mntp: /var/lib/lxc
-
-# Size of LXC LVM backing volume.
-monitoring_lvm_group_data_lv_lxc_size: 60%VG
-
-# Filesystem for LXC LVM backing volume. ext4 allows for shrinking.
-monitoring_lvm_group_data_lv_lxc_fs: ext4
 
 ###############################################################################
 # Monitoring node sysctl configuration.


### PR DESCRIPTION
LXC Monasca services have been replaced with Kolla managed Docker
services.