### PR TITLE
Update to latest Queens release

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -15,7 +15,7 @@ kolla_source_url: https://github.com/stackhpc/kolla.git
 
 # Version (branch, tag, etc.) of Kolla source code repository if type is
 # 'source'.
-kolla_source_version: refs/tags/stackhpc/6.1.0.6
+kolla_source_version: refs/tags/stackhpc/6.2.1.1
 
 # Path to virtualenv in which to install kolla.
 #kolla_venv:
@@ -37,7 +37,7 @@ kolla_ansible_source_url: https://github.com/stackhpc/kolla-ansible.git
 
 # Version (branch, tag, etc.) of Kolla Ansible source code repository if type
 # is 'source'.
-kolla_ansible_source_version: refs/tags/stackhpc/6.1.0.6
+kolla_ansible_source_version: refs/tags/stackhpc/6.2.0.1
 
 # Path to virtualenv in which to install kolla-ansible.
 #kolla_ansible_venv:
@@ -70,7 +70,7 @@ kolla_docker_namespace: stackhpc
 #kolla_docker_registry_password:
 
 # Kolla OpenStack release version. This should be a Docker image tag.
-kolla_openstack_release: 6.1.0.2-2
+kolla_openstack_release: 6.2.1.1-1
 
 # Dict mapping names of sources to their definitions for
 # kolla_install_type=source. See kolla.common.config for details.
@@ -106,20 +106,20 @@ kolla_build_blocks:
     # There is no RDO RPM for this ML2 driver and Kolla's plugin mechanism only
     # supports source builds. Install a locally modified version with a fix for
     # Dell switches until it is released.
-    RUN pip install git+https://github.com/stackhpc/networking-generic-switch@stackhpc/1.0.0.1
+    RUN pip install git+https://github.com/stackhpc/networking-generic-switch@stackhpc/1.0.0.3
     # Install a locally modified version of networking-mlnx with support for
     # disabling the SDN controller sync mechanism in the mlnx_sdn_assist
     # driver. This allows us to bind to flat Infiniband networks.
-    RUN pip install git+https://github.com/stackhpc/networking-mlnx@stackhpc/12.0.0.1
+    RUN pip install git+https://github.com/stackhpc/networking-mlnx@stackhpc/12.1.0.1
   ironic_inspector_footer: |
     # Install our custom inspector plugins.
     RUN pip install stackhpc-inspector-plugins==1.1.1
   magnum_api_footer: |
     # This branch fixes k8s FailedNodeAllocatableEnforcement warning
-    RUN pip install -U --no-deps git+https://github.com/stackhpc/magnum@stackhpc/6.1.1.2
+    RUN pip install -U --no-deps git+https://github.com/stackhpc/magnum@stackhpc/6.3.0.2
   magnum_conductor_footer: |
     # This branch fixes k8s FailedNodeAllocatableEnforcement warning
-    RUN pip install -U --no-deps git+https://github.com/stackhpc/magnum@stackhpc/6.1.1.2
+    RUN pip install -U --no-deps git+https://github.com/stackhpc/magnum@stackhpc/6.3.0.2
   monasca_log_api_footer: |
     # Support for the log query API isn't yet merged upstream. This
     # implicitly pulls in some other packages like voluptous required

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -22,26 +22,26 @@ monasca_agent_authorized_roles:
 # Container image tags.
 # These should be allowed to change independently, as services are updated.
 
-barbican_tag: 6.1.0.2-1
-cron_tag: 6.1.0.2-1
-fluentd_tag: 6.1.0.2-1
-glance_tag: 6.1.0.2-1
-haproxy_tag: 6.1.0.2-1
-heat_tag: 6.1.0.2-1
-horizon_tag: 6.1.0.2-1
-ironic_tag: 6.1.0.2-1
-iscsid_tag: 6.1.0.2-1
-keepalived_tag: 6.1.0.2-1
-keystone_tag: 6.1.0.2-1
-kolla_toolbox_tag: 6.1.0.2-1
-magnum_tag: 6.1.0.2-2
-manila_tag: 6.1.0.2-1
-mariadb_tag: 6.1.0.2-1
-memcached_tag: 6.1.0.2-1
-neutron_tag: 6.1.0.2-2
-nova_tag: 6.1.0.2-1
-openvswitch_tag: 6.1.0.2-1
-rabbitmq_tag: 6.1.0.2-1
+barbican_tag: 6.2.1.1-1
+cron_tag: 6.2.1.1-1
+fluentd_tag: 6.2.1.1-1
+glance_tag: 6.2.1.1-1
+haproxy_tag: 6.2.1.1-1
+heat_tag: 6.2.1.1-1
+horizon_tag: 6.2.1.1-1
+ironic_tag: 6.2.1.1-1
+iscsid_tag: 6.2.1.1-1
+keepalived_tag: 6.2.1.1-1
+keystone_tag: 6.2.1.1-1
+kolla_toolbox_tag: 6.2.1.1-1
+magnum_tag: 6.2.1.1-1
+manila_tag: 6.2.1.1-1
+mariadb_tag: 6.2.1.1-1
+memcached_tag: 6.2.1.1-1
+neutron_tag: 6.2.1.1-1
+nova_tag: 6.2.1.1-1
+openvswitch_tag: 6.2.1.1-1
+rabbitmq_tag: 6.2.1.1-1
 # Use the pike release of Sahara, since our changes have not been ported to
 # Queens.
 sahara_tag: 5.0.3.3-1


### PR DESCRIPTION
Prior to the Rocky upgrade, update all dependencies to the latest Queens
releases.