### PR TITLE
Upgrade InfluxDB to latest release

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -133,7 +133,7 @@ kolla_build_customizations:
   keystone_base_packages_append:
     - 'mod_auth_openidc'
   influxdb_packages_override:
-    - 'influxdb-1.3.7'
+    - 'influxdb-1.7.6'
   ironic_inspector_packages_append:
     # Allow custom packages to be installed via pip.
     - 'python-pip'

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -37,7 +37,7 @@ glance_tag: 7.0.2.1-1
 haproxy_tag: 7.0.2.1-1
 heat_tag: 7.0.2.1-1
 horizon_tag: 7.0.2.1-1
-influxdb_tag: 7.1.0.1
+influxdb_tag: 7.0.2.1-1
 ironic_tag: 7.0.2.1-1
 iscsid_tag: 7.0.2.1-1
 kafka_tag: 7.1.0.1


### PR DESCRIPTION
InfluxDB 1.3 contains a bug which allows a tenant to view
dimensions from all OpenStack projects. This is a security
issue.