### PR TITLE
Move to Monasca Grafana

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -37,7 +37,7 @@ kolla_ansible_source_url: https://github.com/stackhpc/kolla-ansible.git
 
 # Version (branch, tag, etc.) of Kolla Ansible source code repository if type
 # is 'source'.
-kolla_ansible_source_version: refs/tags/stackhpc/7.1.0.3
+kolla_ansible_source_version: refs/tags/stackhpc/7.1.0.4
 
 # Path to virtualenv in which to install kolla-ansible.
 #kolla_ansible_venv:

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -27,8 +27,7 @@ monasca_agent_authorized_roles:
 es_heap_size: "24g"
 
 # Settings to ensure backwords compatibility with Queens Monasca deployment
-# FIXME(dszumski): Switch back to 3000 when issue with new Grafana image is fixed
-monasca_grafana_server_port: "3001"
+monasca_grafana_server_port: "3000"
 monasca_control_plane_project: "monasca"
 monasca_grafana_admin_username: "grafana-admin"
 


### PR DESCRIPTION
In Rocky a dedicated Monasca Grafana container exists. Here
we complete the switch to it.

This also pulls in a fix for Grafana org registration.