### PR TITLE
Support monitoring Rabbit queues

### DIFF
--- a/etc/kayobe/kolla/config/monasca/sv-b16-u23/agent_plugins/rabbitmq.yaml
+++ b/etc/kayobe/kolla/config/monasca/sv-b16-u23/agent_plugins/rabbitmq.yaml
@@ -1,0 +1,21 @@
+{% raw %}
+init_config: null
+instances:
+- built_by: RabbitMQ
+  exchanges:
+  - nova
+  - cinder
+  - glance
+  - keystone
+  - neutron
+  - heat
+  - ironic
+  name: RabbitMQ
+  nodes:
+  - "rabbit@{{ inventory_hostname }}"
+  queues:
+  - conductor
+  rabbitmq_api_url: "http://{{ api_interface_address }}:{{ rabbitmq_management_port }}/api/"
+  rabbitmq_pass: "{{ rabbitmq_monitoring_password }}"
+  rabbitmq_user: "{{ rabbitmq_monitoring_user }}"
+{% endraw %}


### PR DESCRIPTION
We use the host specific override because in production there are
two nodes, and we want to test the 'per-node' mechanism.

The rabbit monitoring user and password have already been created.