### PR TITLE
Add ntp and load plugins for Monasca

### DIFF
--- a/etc/kayobe/kolla/config/monasca/agent_plugins/load.yaml
+++ b/etc/kayobe/kolla/config/monasca/agent_plugins/load.yaml
@@ -1,0 +1,5 @@
+---
+init_config: null
+instances:
+- built_by: System
+  name: load_stats

--- a/etc/kayobe/kolla/config/monasca/agent_plugins/ntp.yaml
+++ b/etc/kayobe/kolla/config/monasca/agent_plugins/ntp.yaml
@@ -1,0 +1,7 @@
+---
+{% raw %}
+init_config: null
+instances:
+- built_by: Ntp
+  host: "{{ external_ntp_servers | first }}"
+{% endraw %}


### PR DESCRIPTION
It seemed better to do this via Kayobe config rather than backport patches from upstream Kolla Ansible.