### PR TITLE
Configure Monasca Grafana user and editor roles

### DIFF
--- a/etc/kayobe/kolla/config/monasca/grafana.ini
+++ b/etc/kayobe/kolla/config/monasca/grafana.ini
@@ -1,0 +1,3 @@
+[auth.keystone]
+editor_roles = monasca-editor
+viewer_roles = monasca-user


### PR DESCRIPTION
Support read only users and editors. Editors no longer
need the admin role.