### PR TITLE
Support time range in dimension name/value queries

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -15,7 +15,7 @@ kolla_source_url: https://github.com/stackhpc/kolla.git
 
 # Version (branch, tag, etc.) of Kolla source code repository if type is
 # 'source'.
-kolla_source_version: refs/tags/stackhpc/7.0.2.2
+kolla_source_version: refs/tags/stackhpc/7.0.2.3
 
 # Path to virtualenv in which to install kolla.
 #kolla_venv:
@@ -73,7 +73,7 @@ kolla_docker_namespace: stackhpc
 #kolla_docker_registry_password:
 
 # Kolla OpenStack release version. This should be a Docker image tag.
-kolla_openstack_release: 7.0.2.2-1
+kolla_openstack_release: 7.0.2.3-1
 
 # Dict mapping names of sources to their definitions for
 # kolla_install_type=source. See kolla.common.config for details.
@@ -116,10 +116,19 @@ kolla_build_blocks:
   sahara_engine_footer: |
     # Bring in hack to the vanilla plugin
     RUN pip install -U --no-deps git+https://github.com/stackhpc/sahara.git@stackhpc/7.0.2.1
+  monasca_api_footer: |
+    # NOTE(brtknr): Install upstream patch currently under review:
+    # https://review.opendev.org/#/c/670318/
+    RUN pip install -U --no-deps git+https://github.com/stackhpc/monasca-api.git@stackhpc/2.7.0.2
   monasca_grafana_footer: |
     # Install plugin for Gantt charts
     RUN grafana-cli plugins install natel-discrete-panel
     RUN grafana-cli plugins install vonage-status-panel
+    # NOTE(brtknr): Install upstream patch currently under review:
+    # https://review.opendev.org/#/c/670316/
+    RUN git clone https://github.com/stackhpc/monasca-grafana-datasource --depth=1 -b stackhpc/1.3.0 \
+        && grafana-cli --pluginsDir monasca-grafana-datasource/ plugins install monasca-datasource \
+        && rm -rf monasca-grafana-datasource/
   monasca_notification_footer: |
     # Bring in Slack template patch and fixes for notification plugins
     # TODO(dszumski): When the following are merged, we can create a new

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -54,6 +54,8 @@ manila_tag: 7.0.2.1-1
 mariadb_tag: 7.0.2.1-1
 memcached_tag: 7.0.2.1-1
 monasca_tag: 7.1.0.1
+monasca_api_tag: 7.0.2.3-1
+monasca_grafana_tag: 7.0.2.3-1
 monasca_log_api_tag: 7.0.2.2-1
 monasca_notification_tag: 7.0.2.2-1
 neutron_tag: 7.0.2.1-1


### PR DESCRIPTION
To achieve this, monasca-api and monasca-grafana containers are patched
with upstream changes which enable this support.

Commands run:
```
kayobe overcloud container image build monasca-api -e kolla_install_type=source --push
kayobe overcloud container image build monasca-grafana -e kolla_install_type=source --push
kayobe overcloud service reconfigure -kt monasca
```