### PR TITLE
Use stackhpc monasca-grafana v4.2.0 rebase (test)

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -167,8 +167,6 @@ kolla_build_customizations:
   sahara_base_packages_append:
     # Allow custom packages to be installed via pip.
     - 'python-pip'
-  monasca_grafana_version_override:
-    - 'v4.2.0'
   monasca_grafana_url_override:
     - 'https://github.com/stackhpc/grafana/archive/v4.2.0.tar.gz'
 

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -140,7 +140,7 @@ kolla_build_blocks:
   monasca_grafana_arguments: |
     ENV monasca_grafana_build_path=${GO_PATH}/src/github.com/grafana/grafana
     ARG monasca_grafana_version=v4.2.0
-    ARG monasca_grafana_url=https://github.com/monasca/grafana/archive/$monasca_grafana_version.tar.gz
+    ARG monasca_grafana_url=https://github.com/stackhpc/grafana/archive/$monasca_grafana_version.tar.gz
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -15,7 +15,7 @@ kolla_source_url: https://github.com/stackhpc/kolla.git
 
 # Version (branch, tag, etc.) of Kolla source code repository if type is
 # 'source'.
-kolla_source_version: refs/tags/stackhpc/7.0.2.3
+kolla_source_version: refs/tags/stackhpc/7.0.2.4-wip
 
 # Path to virtualenv in which to install kolla.
 #kolla_venv:
@@ -137,27 +137,10 @@ kolla_build_blocks:
     # https://review.opendev.org/#/c/656780/
     # https://review.opendev.org/#/c/656783/
     RUN pip install -U --no-deps git+https://github.com/stackhpc/monasca-notification@stackhpc/1.14.0.3
-  monasca_grafana_install: |
-    RUN gem install rake fpm \
-        && curl -sSL -o /tmp/monasca-grafana.tgz https://github.com/stackhpc/grafana/archive/v4.2.0.tar.gz \
-        && mkdir -p ${monasca_grafana_build_path} \
-        && tar --strip 1 -xvf /tmp/monasca-grafana.tgz -C ${monasca_grafana_build_path} \
-        && rm -f /tmp/monasca-grafana.tgz \
-        && cd ${monasca_grafana_build_path} \
-        && go run build.go setup \
-        && npm install -g yarn \
-        && yarn \
-        && go run build.go build package \
-        && mv ${monasca_grafana_build_path}/dist /grafana_pkgs \
-        && rm -rf /grafana
-
-    {% if base_package_type == 'rpm' %}
-      {% set monasca_grafana_packages = ['/grafana_pkgs/grafana*.rpm'] %}
-    {% elif base_package_type == 'deb' %}
-      {% set monasca_grafana_packages = ['/grafana_pkgs/grafana*.deb'] %}
-    {% endif %}
-
-    {{ macros.install_packages(monasca_grafana_packages | customizable("packages")) }}
+  monasca_grafana_arguments: |
+    ENV monasca_grafana_build_path=${GO_PATH}/src/github.com/grafana/grafana
+    ARG monasca_grafana_version=v4.2.0
+    ARG monasca_grafana_url=https://github.com/monasca/grafana/archive/$monasca_grafana_version.tar.gz
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -73,7 +73,7 @@ kolla_docker_namespace: stackhpc
 #kolla_docker_registry_password:
 
 # Kolla OpenStack release version. This should be a Docker image tag.
-kolla_openstack_release: 7.0.2.3-1
+kolla_openstack_release: 7.0.2.3-2
 
 # Dict mapping names of sources to their definitions for
 # kolla_install_type=source. See kolla.common.config for details.
@@ -167,6 +167,10 @@ kolla_build_customizations:
   sahara_base_packages_append:
     # Allow custom packages to be installed via pip.
     - 'python-pip'
+  monasca_grafana_version_override:
+    - 'v4.2.0'
+  monasca_grafana_url_override:
+    - 'https://github.com/stackhpc/grafana/archive/v4.2.0.tar.gz'
 
 ###############################################################################
 # Kolla-ansible inventory configuration.

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -73,7 +73,7 @@ kolla_docker_namespace: stackhpc
 #kolla_docker_registry_password:
 
 # Kolla OpenStack release version. This should be a Docker image tag.
-kolla_openstack_release: 7.0.2.3-2
+kolla_openstack_release: 7.0.2.3-1
 
 # Dict mapping names of sources to their definitions for
 # kolla_install_type=source. See kolla.common.config for details.
@@ -167,8 +167,6 @@ kolla_build_customizations:
   sahara_base_packages_append:
     # Allow custom packages to be installed via pip.
     - 'python-pip'
-  monasca_grafana_url_override:
-    - 'https://github.com/stackhpc/grafana/archive/v4.2.0.tar.gz'
 
 ###############################################################################
 # Kolla-ansible inventory configuration.

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -73,7 +73,7 @@ kolla_docker_namespace: stackhpc
 #kolla_docker_registry_password:
 
 # Kolla OpenStack release version. This should be a Docker image tag.
-kolla_openstack_release: 7.0.2.3-1
+kolla_openstack_release: 7.0.2.3-2
 
 # Dict mapping names of sources to their definitions for
 # kolla_install_type=source. See kolla.common.config for details.
@@ -137,6 +137,27 @@ kolla_build_blocks:
     # https://review.opendev.org/#/c/656780/
     # https://review.opendev.org/#/c/656783/
     RUN pip install -U --no-deps git+https://github.com/stackhpc/monasca-notification@stackhpc/1.14.0.3
+  monasca_grafana_install: |
+    RUN gem install rake fpm \
+        && curl -sSL -o /tmp/monasca-grafana.tgz https://github.com/stackhpc/grafana/archive/v4.2.0.tar.gz \
+        && mkdir -p ${monasca_grafana_build_path} \
+        && tar --strip 1 -xvf /tmp/monasca-grafana.tgz -C ${monasca_grafana_build_path} \
+        && rm -f /tmp/monasca-grafana.tgz \
+        && cd ${monasca_grafana_build_path} \
+        && go run build.go setup \
+        && npm install -g yarn \
+        && yarn \
+        && go run build.go build package \
+        && mv ${monasca_grafana_build_path}/dist /grafana_pkgs \
+        && rm -rf /grafana
+
+    {% if base_package_type == 'rpm' %}
+      {% set monasca_grafana_packages = ['/grafana_pkgs/grafana*.rpm'] %}
+    {% elif base_package_type == 'deb' %}
+      {% set monasca_grafana_packages = ['/grafana_pkgs/grafana*.deb'] %}
+    {% endif %}
+
+    {{ macros.install_packages(monasca_grafana_packages | customizable("packages")) }}
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -55,7 +55,7 @@ mariadb_tag: 7.0.2.1-1
 memcached_tag: 7.0.2.1-1
 monasca_tag: 7.1.0.1
 monasca_api_tag: 7.0.2.3-1
-monasca_grafana_tag: 7.0.2.3-2
+monasca_grafana_tag: 7.0.2.3-1
 monasca_log_api_tag: 7.0.2.2-1
 monasca_notification_tag: 7.0.2.2-1
 neutron_tag: 7.0.2.1-1

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -55,7 +55,7 @@ mariadb_tag: 7.0.2.1-1
 memcached_tag: 7.0.2.1-1
 monasca_tag: 7.1.0.1
 monasca_api_tag: 7.0.2.3-1
-monasca_grafana_tag: 7.0.2.3-1
+monasca_grafana_tag: 7.0.2.3-2
 monasca_log_api_tag: 7.0.2.2-1
 monasca_notification_tag: 7.0.2.2-1
 neutron_tag: 7.0.2.1-1


### PR DESCRIPTION
This includes the config needed to build and deploy an updated monasca-grafana (v4.2.0). 