### PR TITLE
Install monasca-grafana (v1.3.0) plugin on a non-persistent volume

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -37,7 +37,7 @@ kolla_ansible_source_url: https://github.com/stackhpc/kolla-ansible.git
 
 # Version (branch, tag, etc.) of Kolla Ansible source code repository if type
 # is 'source'.
-kolla_ansible_source_version: refs/tags/stackhpc/7.1.1.2
+kolla_ansible_source_version: refs/tags/stackhpc/7.1.1.3
 
 # Path to virtualenv in which to install kolla-ansible.
 #kolla_ansible_venv:
@@ -73,7 +73,7 @@ kolla_docker_namespace: stackhpc
 #kolla_docker_registry_password:
 
 # Kolla OpenStack release version. This should be a Docker image tag.
-kolla_openstack_release: 7.0.2.6-2
+kolla_openstack_release: 7.0.2.6-3
 
 # Dict mapping names of sources to their definitions for
 # kolla_install_type=source. See kolla.common.config for details.
@@ -126,9 +126,11 @@ kolla_build_blocks:
     RUN grafana-cli plugins install vonage-status-panel
     # NOTE(brtknr): Install upstream patch currently under review:
     # https://review.opendev.org/#/c/670316/
-    RUN git clone https://github.com/stackhpc/monasca-grafana-datasource --depth=1 -b stackhpc/1.3.0 \
-        && grafana-cli --pluginsDir monasca-grafana-datasource/ plugins install monasca-datasource \
-        && rm -rf monasca-grafana-datasource/
+    RUN grafana-cli plugins remove monasca-datasource \
+        && curl -sSL -o /tmp/monasca-grafana-datasource.tgz https://github.com/stackhpc/monasca-grafana-datasource/archive/stackhpc/1.3.0.tar.gz \
+        && mkdir -p /var/lib/grafana/plugins/monasca-datasource \
+        && tar --strip 1 -xvf /tmp/monasca-grafana-datasource.tgz -C /var/lib/grafana/plugins/monasca-datasource \
+        && rm -f /tmp/monasca-grafana-datasource.tgz
   monasca_notification_footer: |
     # Bring in Slack template patch and fixes for notification plugins
     # TODO(dszumski): When the following are merged, we can create a new

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -55,7 +55,7 @@ mariadb_tag: 7.0.2.1-1
 memcached_tag: 7.0.2.1-1
 monasca_tag: 7.1.0.1
 monasca_api_tag: 7.0.2.3-1
-monasca_grafana_tag: 7.0.2.6-2
+monasca_grafana_tag: 7.0.2.6-3
 monasca_log_api_tag: 7.0.2.2-1
 monasca_notification_tag: 7.0.2.2-1
 monasca_thresh_tag: 7.0.2.6-1


### PR DESCRIPTION
Removes v1 monasca datasource installed during build, replaces with v1.3.0