### PR TITLE
Add ansible-vault files to .gitattributes and .gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Configure git to use `ansible-vault view` for diff'ing these files with:
+# git config --global diff.ansible-vault.textconv "ansible-vault view"
+etc/kayobe/secrets.yml diff=ansible-vault merge=binary
+etc/kayobe/kolla/passwords.yml diff=ansible-vault merge=binary

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ etc/kayobe/inventory/group_vars/seed/ansible-host
 
 # Ignore kolla configuration.
 etc/kolla
+
+# Ignore ansible vault password
+.vault_password


### PR DESCRIPTION
This allows devs to use git diff to view changes in `secrets.yml` and `passwords.yml` provided they have run `git config --global diff.ansible-vault.textconv "ansible-vault view"`.

Optional - Can also add the following to `~/.ansible.cfg` to look for `.vault_password` in the current working directory:
```
[defaults]
vault_password_file = $PWD/.vault_password
```