### PR TITLE
Update neutron images

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -73,7 +73,7 @@ kolla_docker_namespace: stackhpc
 #kolla_docker_registry_password:
 
 # Kolla OpenStack release version. This should be a Docker image tag.
-kolla_openstack_release: 7.0.2.6-4
+kolla_openstack_release: 7.0.2.6-5
 
 # Dict mapping names of sources to their definitions for
 # kolla_install_type=source. See kolla.common.config for details.

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -60,7 +60,7 @@ monasca_log_api_tag: 7.0.2.2-1
 monasca_notification_tag: 7.0.2.2-1
 monasca_persister_tag: 7.0.2.6-4
 monasca_thresh_tag: 7.0.2.6-1
-neutron_tag: 7.0.2.1-1
+neutron_tag: 7.0.2.6-5
 nova_tag: 7.0.2.1-1
 openvswitch_tag: 7.0.2.1-1
 rabbitmq_tag: 7.0.2.1-1


### PR DESCRIPTION
There is a memory leak in the neutron agents, which can be fixed by rebuilding
neutron container images with updated RDO packages.