### PR TITLE
Reduce size of docker volumes logical volume

### DIFF
--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -49,7 +49,7 @@ seed_lvm_group_data_disks:
 #seed_lvm_group_data_lv_docker_volumes:
 
 # Size of docker volumes LVM backing volume.
-#seed_lvm_group_data_lv_docker_volumes_size:
+seed_lvm_group_data_lv_docker_volumes_size: 30G
 
 # Filesystem for docker volumes LVM backing volume. ext4 allows for shrinking.
 #seed_lvm_group_data_lv_docker_volumes_fs:


### PR DESCRIPTION
We weren't using much of the capacity and we needed more space
in the thin pool:

 && yum clean all && rm -rf /var/cache/yum", "ERROR:kolla.common.utils.monasca-base:Error'd with the following message", "ERROR:kolla.common.utils.monasca-base:devmapper: Thin Pool has 12625 free data blocks which is less than minimum required 12680 free data blocks. Create more free space in thin pool or use dm.min_free_space option to change behavior"

even after a `docker image prune -a`