### PR TITLE
Updates kolla_source_version to re-add monasca grafana plugin

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -15,7 +15,7 @@ kolla_source_url: https://github.com/stackhpc/kolla.git
 
 # Version (branch, tag, etc.) of Kolla source code repository if type is
 # 'source'. Default is {{ openstack_branch }}.
-kolla_source_version: stackhpc/8.0.1.1
+kolla_source_version: stackhpc/8.0.1.3
 
 # Path to virtualenv in which to install kolla.
 #kolla_venv:
@@ -74,7 +74,7 @@ kolla_docker_namespace: stackhpc
 
 # Kolla OpenStack release version. This should be a Docker image tag.
 # Default is {{ openstack_release }}.
-kolla_openstack_release: 8.0.1.1-2
+kolla_openstack_release: 8.0.1.3-1
 
 # Dict mapping names of sources to their definitions for
 # kolla_install_type=source. See kolla.common.config for details.

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -58,7 +58,7 @@ mariadb_tag: 8.0.1.1-1
 memcached_tag: 8.0.1.1-1
 monasca_tag: 8.0.1.1-1
 monasca_api_tag: 8.0.1.1-1
-monasca_grafana_tag: 8.0.1.1-1
+monasca_grafana_tag: 8.0.1.3-1
 monasca_log_api_tag: 8.0.1.1-1
 monasca_notification_tag: 8.0.1.1-1
 monasca_persister_tag: 8.0.1.1-2


### PR DESCRIPTION
Now ported to stackhpc/stein (8.0.1.3), re-adds the lost Monasca Grafana plugin.
Includes unrelated fixes from 8.0.1.2.