### PR TITLE
Disable Chrony (again)

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -32,6 +32,9 @@ monasca_grafana_server_port: "3000"
 monasca_control_plane_project: "monasca"
 monasca_grafana_admin_username: "grafana-admin"
 
+# Disable chrony container - use ntpd on the host.
+enable_chrony: false
+
 # Container image tags.
 # These should be allowed to change independently, as services are updated.
 


### PR DESCRIPTION
`kayobe overcloud container image pull` commands now fail attempting to pull Chrony. This patch disables Chrony again. 