### PR TITLE
Add ceph node monasca agent playbook

### DIFF
--- a/etc/kayobe/ansible/monasca_ceph_monitoring.yml
+++ b/etc/kayobe/ansible/monasca_ceph_monitoring.yml
@@ -1,0 +1,36 @@
+---
+- name: Deploy Monasca-rsyslog on Ceph nodes
+  hosts: ceph
+  become: true
+  roles:
+  - role: stackhpc.monasca-rsyslog
+    monasca_rsyslog_api_auth:
+      auth_url: "http://{{ ilab_vip_address }}:5000"
+      project: "monasca"
+      username: "monasca-agent"
+      password: "{{ secrets_monasca_agent_password }}"
+      region_name: "RegionOne"
+      endpoint_type: "public"
+    monasca_rsyslog_venv: "/usr/libexec/monasca-rsyslog"
+
+- name: Deploy Monasca Agent
+  hosts: ceph
+  become: true
+  roles:
+  - role: stackhpc.monasca-agent
+    keystone_url: "http://{{ ilab_vip_address }}:5000/v3"
+    monasca_user: root
+    monasca_agent_user: "monasca-agent"
+    monasca_agent_password: "{{ secrets_monasca_agent_password }}"
+    monasca_agent_project: "monasca"
+    monasca_agent_git_repo: https://github.com/stackhpc/monasca-agent
+    monasca_agent_branch: story-2005032
+    monasca_pip_extra_args: "-c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/stein"
+    monasca_endpoint_type: null
+    monasca_project_domain_name: Default
+    monasca_user_domain_name: Default
+    monasca_region_name: "RegionOne"
+    monasca_service_type: monitoring
+    monasca_log_level: INFO
+    monasca_agent_custom_plugin_repos:
+    - "https://github.com/stackhpc/stackhpc-monasca-agent-plugins.git"


### PR DESCRIPTION
Adds kayobe custom playbook for deploying monasca-agent to ceph nodes. Uses luminous ceph compatability branch.