### PR TITLE
Revert manila to rocky

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -52,7 +52,7 @@ kibana_tag: 8.0.1.1-1
 kolla_toolbox_tag: 8.0.1.1-1
 logstash_tag: 8.0.1.1-1
 magnum_tag: 8.0.1.2-1
-manila_tag: 8.0.1.1-1
+manila_tag: 7.0.4.1-1
 mariadb_tag: 8.0.1.1-1
 memcached_tag: 8.0.1.1-1
 monasca_tag: 8.0.1.1-1


### PR DESCRIPTION
In the light of this bug, we need to revert manila to rocky: https://bugs.launchpad.net/kolla-ansible/+bug/1855885 until Manila team add support for Nautilus or Kolla restricts ceph version to Mimic.