### PR TITLE
Fixes Monasca log transformer UTC offset exception

### DIFF
--- a/etc/kayobe/kolla/config/monasca/log-transformer.conf
+++ b/etc/kayobe/kolla/config/monasca/log-transformer.conf
@@ -27,7 +27,7 @@ input {
 filter {
     # Update the timestamp of the event based on the time in the message.
     date {
-        match => [ "[log][dimensions][timestamp]", "yyyy-MM-dd HH:mm:ss +0000", "ISO8601"]
+        match => [ "[log][dimensions][timestamp]", "yyyy-MM-dd HH:mm:ss Z", "ISO8601"]
         remove_field => [ "[log][dimensions][timestamp]", "[log][dimensions][Timestamp]" ]
     }
 


### PR DESCRIPTION
Monasca log transformer currently throws exceptions on encountering a
non-UTC time offset (+0000):
"""
"exception": "Invalid format: \"2019-08-08 17:39:45 +0100\" is malformed at \" +0100\"",
"config_parsers":"yyyy-MM-dd HH:mm:ss +0000,ISO8601"}
"""

This fix allows logstash to interpret any valid ISO8601 offset.

Change-Id: Id70c3dd9cdcf681e955931f18a054e19cc284c0a
Closes-Bug: #1839597